### PR TITLE
add small script to compare PLZ data with map data

### DIFF
--- a/utils/analyseData/compareGeospatialData/compare.js
+++ b/utils/analyseData/compareGeospatialData/compare.js
@@ -1,0 +1,105 @@
+const fs = require("fs");
+const csv = require("csv-parser");
+const createCsvWriter = require("csv-writer").createObjectCsvWriter;
+
+// ---- Utils ----------------------------------------------------------------------------
+
+const extraLogs = false;
+
+const readCSV = (path) => {
+  return new Promise((res, rej) => {
+    const arr = [];
+    fs.createReadStream(path)
+      .pipe(csv())
+      .on("data", (data) => arr.push(data))
+      .on("end", () => {
+        res(arr);
+      });
+  });
+};
+
+const getSet = (arr, prop) => {
+  return [...new Set(arr.map((x) => x[prop]))];
+};
+const getUniquePropLength = (arr, prop) => {
+  return getSet(arr, prop).length;
+};
+
+//--------------------------------------------------------------------------------------//
+//                                      Comparison                                      //
+//--------------------------------------------------------------------------------------//
+// Paths to compare
+const PLZPath = "zuordnung_plz_ort_landkreis.csv";
+const gemeindePath = "gemeinden_simplify200.geojson";
+
+// Read and parse those files
+const readFiles = async () => {
+  const PLZs = await readCSV(PLZPath);
+  const raw = fs.readFileSync(gemeindePath, "utf8");
+  const gemeinden = JSON.parse(raw).features;
+  return { PLZs, gemeinden };
+};
+
+const compareFiles = async () => {
+  const { PLZs, gemeinden } = await readFiles();
+
+  // Exclude the feature geometry
+  const gemeindenProps = gemeinden.map((x) => x.properties);
+  if (extraLogs) {
+    console.log("Example gemeindenProps: ", gemeindenProps[0]);
+    console.log("Example PLZs: ", PLZs[0]);
+  }
+
+  // Compare lengths
+  const gemeindenLength = getUniquePropLength(gemeindenProps, "AGS");
+  const plzLength = getUniquePropLength(PLZs, "ags");
+  console.log("Gemeinden length: ", gemeinden.length);
+  console.log("Unique AGS Gemeinden length: ", gemeindenLength);
+  console.log("Unique AGS PLZ length: ", plzLength);
+
+  // ---- Compare AGS Sets -----------------------------------------------------------------
+  const gemeindenSet = getSet(gemeindenProps, "AGS");
+  const plzSet = getSet(PLZs, "ags");
+
+  // isSubset?
+  const isPLZSubsetOfGemeinden = plzSet.every((x) => gemeindenSet.includes(x));
+  console.log("PLZs AGS is subset of gemeinden AGS: ", isPLZSubsetOfGemeinden);
+
+  // AGS that are not in gemeindenSet
+  const notMatchingAGS = plzSet.filter((x) => !gemeindenSet.includes(x));
+  console.log("PLZs AGS that are not in gemeinden", notMatchingAGS.length);
+
+  // Match back to PLZs
+  const plzNotInGemeinden = notMatchingAGS.map((x) =>
+    PLZs.find((y) => y.ags === x)
+  );
+
+  // Compare by Name
+  const matchMissingByName = plzNotInGemeinden
+    .map((x) => gemeindenProps.find((y) => y.GEN === x.ort))
+    .filter((x) => !!x);
+  console.log("Matched missing AGS by name: ", matchMissingByName.length);
+
+  // ---- Write out communities that are missing in the gemeindenSet ---------------------------
+  // To csv for a table
+  const csvWriter = createCsvWriter({
+    path: "not-matching-plzs.csv",
+    header: [
+      { id: "ags", title: "AGS" },
+      { id: "ort", title: "Name" },
+      { id: "plz", title: "PLZ" },
+      { id: "bundesland", title: "Bundesland" },
+    ],
+  });
+  csvWriter.writeRecords(plzNotInGemeinden);
+
+  // JSON if prefered
+  if (extraLogs) {
+    fs.writeFileSync(
+      "not-matching-plzs.json",
+      JSON.stringify(plzNotInGemeinden, null, 2)
+    );
+  }
+};
+
+compareFiles();

--- a/utils/analyseData/compareGeospatialData/package-lock.json
+++ b/utils/analyseData/compareGeospatialData/package-lock.json
@@ -1,0 +1,69 @@
+{
+  "name": "compare",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "csv-parser": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/csv-parser/-/csv-parser-2.3.3.tgz",
+      "integrity": "sha512-czcyxc4/3Tt63w0oiK1zsnRgRD4PkqWaRSJ6eef63xC0f+5LVLuGdSYEcJwGp2euPgRHx+jmlH2Lb49anb1CGQ==",
+      "requires": {
+        "minimist": "^1.2.0",
+        "through2": "^3.0.1"
+      }
+    },
+    "csv-writer": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/csv-writer/-/csv-writer-1.6.0.tgz",
+      "integrity": "sha512-NOx7YDFWEsM/fTRAJjRpPp8t+MKRVvniAg9wQlUKx20MFrPs73WLJhFf5iteqrxNYnsy924K3Iroh3yNHeYd2g=="
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+    },
+    "readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "through2": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
+      "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
+      "requires": {
+        "inherits": "^2.0.4",
+        "readable-stream": "2 || 3"
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    }
+  }
+}

--- a/utils/analyseData/compareGeospatialData/package.json
+++ b/utils/analyseData/compareGeospatialData/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "compare",
+  "version": "1.0.0",
+  "description": "Annahme: Schlüssel (uid) ist der AGS-Code (Amtlicher Gemeinde Schlüssel)",
+  "main": "compare.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "csv-parser": "^2.3.3",
+    "csv-writer": "^1.6.0"
+  }
+}

--- a/utils/analyseData/compareGeospatialData/readme.md
+++ b/utils/analyseData/compareGeospatialData/readme.md
@@ -1,0 +1,22 @@
+# Vergleich zwischen OpenDataLab Gemeindedaten und suche-postleitzahl.org PLZ-Daten
+
+Prüfen der Annahme, dass die beiden Datensätze mit einender kombinierbar sind über die UID (Schlüssel) AGS.
+
+## 1. Datenquellen
+
+1. Download der OpenDataLab .geojson-Datei hier: http://opendatalab.de/projects/geojson-utilities/
+2. Download der suche-postleitzahl.org .csv-Datei hier: https://www.suche-postleitzahl.org/downloads
+
+## 2. Script
+
+```bash
+npm i
+node compare.js
+```
+
+Für ein paar extra Logs, gibt es eine Variable in der Utils-Sektion, die beim Weiterarbeiten interessant sind, aber für das Ergebnis nicht so wichtig.
+
+## 3. Ergebnis
+
+- Die Anzahl der individuellen AGS ist bei den OpenDataLab Gemeindedaten um 395 größer, darin sind aber auch gemeindefreie Gebiete enthalten.
+- Die PLZ-Daten werden vollständig von den OpenDataLab Gemeindedaten abgedeckt. 24 fehlen bei einer Überprüfung der AGS, 8 weitere können über den Gemeindenamen verknüpft werden.


### PR DESCRIPTION
Script to test if the two data sets we want to use for searching districts by zip code and visualize them on a map can be merged on the unique AGS key (Amtlicher Gemeindeschlüssel). More details in the readme.md in the new folder.