### PR TITLE
Resend email with code if client requests it

### DIFF
--- a/serverless/src/triggers/auth/verifyAuthChallengeResponse/index.js
+++ b/serverless/src/triggers/auth/verifyAuthChallengeResponse/index.js
@@ -1,8 +1,13 @@
+const { sendEmail } = require('../createAuthChallenge');
+
 exports.handler = async event => {
   const expectedAnswer =
     event.request.privateChallengeParameters.secretLoginCode;
   if (event.request.challengeAnswer === expectedAnswer) {
     event.response.answerCorrect = true;
+  } else if (event.request.challengeAnswer === 'resendCode') {
+    await sendEmail(event.request.userAttributes, expectedAnswer);
+    event.response.answerCorrect = false;
   } else {
     event.response.answerCorrect = false;
   }


### PR DESCRIPTION
Resolves: https://trello.com/c/NocPW1kI/783-gleichen-code-beim-login-erneut-senden-05

Cognito triggers now check if the sent code is "resendCode". If yes we send another email with the same code as before. User loses one attempt to answer challenge correctly though. 