### PR TITLE
Catch rate limit error when sending login code

### DIFF
--- a/serverless/src/shared/utils/index.js
+++ b/serverless/src/shared/utils/index.js
@@ -97,6 +97,10 @@ const formatPhoneNumber = phoneNumber => {
   return string.replace(new RegExp('[()/-\\s]', 'g'), '').replace('+', '00');
 };
 
+const sleep = ms => {
+  return new Promise(resolve => setTimeout(resolve, ms));
+};
+
 module.exports = {
   constructCampaignId,
   generateRandomId,
@@ -108,4 +112,5 @@ module.exports = {
   validateZipCode,
   validatePhoneNumber,
   formatPhoneNumber,
+  sleep,
 };


### PR DESCRIPTION
In the function in which the login code is sent we catch the rate limit error and try again until it works. 