### PR TITLE
Use only generic emblem for now

### DIFF
--- a/serverless/src/misc/shareMunicipality/index.js
+++ b/serverless/src/misc/shareMunicipality/index.js
@@ -253,10 +253,13 @@ const createRenderedImage = async (
   municipalityName
 ) => {
   try {
-    const emblem = await jimp.read(`${emblemBucketUrl}/${ags}.png`);
+    // Note: deactived using real emblem for now due to legal reasons
+    // const emblem = await jimp.read(`${emblemBucketUrl}/${ags}.png`);
+    const genericEmblem = await jimp.read(`https:${templates.emblemUrl}`);
+
     return createCompositeImage(
       templates.templateUrl,
-      emblem,
+      genericEmblem,
       profilePictureUrl,
       captions,
       username,


### PR DESCRIPTION
Pretty basic change in the backend to only use the generic emblem

To test: try sharing: https://6036744cb22d67338922ab41--expedition-grundeinkommen.netlify.app