### PR TITLE
Finalized goal mail

### DIFF
--- a/serverless/src/triggers/municipalities/sendGoalMails/index.js
+++ b/serverless/src/triggers/municipalities/sendGoalMails/index.js
@@ -50,11 +50,9 @@ const analyseMunicipalities = async municipalities => {
   for (const { signups, goal, ags } of municipalities) {
     const ratio = signups / goal;
     const reached50 = ratio >= 0.5 && ratio < 1;
+    const reachedGoal = ratio >= 1;
 
-    // NOTE: not needed for now, will be reactivated soon
-    // const reachedGoal = ratio >= 1;
-
-    if (reached50) {
+    if (reached50 || reachedGoal) {
       // Get municipality to get name
       const { Item } = await getMunicipality(ags);
 
@@ -64,7 +62,10 @@ const analyseMunicipalities = async municipalities => {
         const event = reached50 ? '50' : 'goal';
 
         // For testing purposes send mail for specific municipality in dev stage
-        if (stage === 'prod' || (stage === 'dev' && ags === '14628230')) {
+        if (
+          stage === 'prod' ||
+          (stage === 'dev' && (ags === '14628230' || ags === '14713000'))
+        ) {
           // Send mail to all users
           await sendMailsForMunicipality(municipality, event, ratio);
 
@@ -86,7 +87,7 @@ const sendMailsForMunicipality = async (municipality, event, ratio) => {
     // Get user record from users table to get email, username etc
     const result = await getUser(userId);
 
-    // Check if we have already set the flags for this user
+    // Check if we have already set the flag (depending on the event) for this user
     // and user still exists.
     // And we also want to only send the email, if the user signed up for the municipality
     // more than 40 hours ago, so that the user does not receive the welcome mail
@@ -94,7 +95,9 @@ const sendMailsForMunicipality = async (municipality, event, ratio) => {
     if (
       'Item' in result &&
       result.Item.newsletterConsent.value &&
-      (typeof mails === 'undefined' || !mails.sentReached50) &&
+      (typeof mails === 'undefined' ||
+        (event === '50' && !mails.sentReached50) ||
+        !mails.sentReachedGoal) &&
       new Date() - new Date(createdAt) > FOURTY_HOURS
     ) {
       await sendMail(result.Item, municipality, event, ratio);

--- a/serverless/src/triggers/municipalities/sendGoalMails/index.js
+++ b/serverless/src/triggers/municipalities/sendGoalMails/index.js
@@ -97,7 +97,7 @@ const sendMailsForMunicipality = async (municipality, event, ratio) => {
       result.Item.newsletterConsent.value &&
       (typeof mails === 'undefined' ||
         (event === '50' && !mails.sentReached50) ||
-        !mails.sentReachedGoal) &&
+        (event === 'goal' && !mails.sentReachedGoal)) &&
       new Date() - new Date(createdAt) > FOURTY_HOURS
     ) {
       await sendMail(result.Item, municipality, event, ratio);


### PR DESCRIPTION
Also activated the mail being sent when a municipality reached the goal. The flow is the same as the previous pr for the 50% mail. 

Every user who signed up for the municipality receives an email. Only users who have signed up for the municipality more than 40 hours ago will receive an email. If they did, a flag ist set for them so they don't receive it twice.

To test:

Either: Locally (or anywhere where the dev backend is connected, you could also use a rest client) sign up for municipality "Leipzig" (ags=14713000). Because you need to have signed up for the municipality you have to alter the createdAt timestamp to a few days ago. You can query the record that was created as seen in the screenshot below. Your user also needs to have newsletterConsent set to true.
Or (probably easier): just change the ags of your test of the previous pr to Leipzigs ags 4713000 (you can query all of your signups as below while leaving out the ags in the query).  

Then invoke the function by calling sls invoke -f sendGoalMails in the /serverless folder of your backend repo. You should receive an email. If you invoke it again no email should be send, because a flag "sentReachedGoal" was set in dev-users-municipalities table. Please also check if the flag was set correctly (same query as in the screenshot).

Thanks!

![grafik](https://user-images.githubusercontent.com/19264520/112310629-197c4880-8ca5-11eb-81a8-18177017c405.png)
