### PR TITLE
Newsletter settings fix

### DIFF
--- a/serverless/src/api/users/updateUser/index.js
+++ b/serverless/src/api/users/updateUser/index.js
@@ -207,13 +207,23 @@ const updateUser = async (
   ) {
     // If array already exists, use that array
     customNewslettersArray = user.customNewsletters || [];
-    customNewslettersArray.push({
-      name: municipalityName,
-      ags,
-      value: true,
-      extraInfo: false,
-      timestamp,
-    });
+
+    // Check if the municipality is already included in the array
+    const foundIndex = customNewslettersArray.findIndex(
+      newsletter => newsletter.ags === ags
+    );
+
+    if (foundIndex !== -1) {
+      customNewslettersArray[foundIndex].value = true;
+    } else {
+      customNewslettersArray.push({
+        name: municipalityName,
+        ags,
+        value: true,
+        extraInfo: false,
+        timestamp,
+      });
+    }
   }
 
   // If the store object was passed we want to get the current store object
@@ -409,8 +419,8 @@ const computeDebitDate = now => {
     date.setMonth(2);
     date.setDate(4);
   } else {
-    // If it is already passed the 14th we set it to next month
-    if (now.getDate() >= 15) {
+    // If it is already passed the 11th at 3 pm we set it to next month
+    if (now.getDate() > 11 || (now.getDate() === 11 && now.getHours() > 14)) {
       date.setMonth(now.getMonth() + 1);
     }
 


### PR DESCRIPTION
Resolves: https://expedition-grundeinkommen.monday.com/boards/853311751/pulses/1136846751

The issue was: If a user already had municipality x in their newsletter settings and was then signing up for that municipality, it was added again. 

To test: sign up for a municipality, for which you are not yet signed  up for, but for which you already get the newsletter. Check, if it is only saved once in the user record (you can just check in the profile). 

To deploy after merging: sls deploy -f updateUser -s prod