### PR TITLE
Custom user confirmation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ list*.pdf
 !utils/seedDatabase/fillMunicipalities/data/plz-3-meinbge-user-promille.csv
 utils/seedDatabase/createMunicipalityShareImages/municipalityImages
 utils/seedDatabase/createMunicipalityShareImages/output
+secretConfig.js

--- a/serverless/serverless.yml
+++ b/serverless/serverless.yml
@@ -628,6 +628,25 @@ functions:
               - - { 'Fn::GetAtt': ['UsersTable', 'Arn'] }
                 - 'index/emailIndex'
 
+  confirmUser:
+    handler: src/api/users/confirmUser/index.handler
+    events:
+      - http:
+          path: users/{userId}/confirm
+          method: post
+          cors: true
+          request:
+            parameters:
+              paths:
+                userId: true # not optional
+    iamRoleStatements:
+      - Effect: 'Allow'
+        Action:
+          - dynamodb:GetItem
+          - dynamodb:UpdateItem
+        Resource:
+          - 'Fn::GetAtt': [UsersTable, Arn]
+
   createSurveyAnswer:
     handler: src/api/users/createSurveyAnswer/index.handler
     events:

--- a/serverless/src/api/users/confirmUser/index.js
+++ b/serverless/src/api/users/confirmUser/index.js
@@ -1,0 +1,73 @@
+/**
+ * This function is used as a secondary option to confirm the user (e.g. if first login via code did not work).
+ * A token is being sent via the request and if the token is the same as the one in the database, we confirm the user.
+ */
+
+const AWS = require('aws-sdk');
+const { errorResponse } = require('../../../shared/apiResponse');
+const { getUser } = require('../../../shared/users');
+
+const ddb = new AWS.DynamoDB.DocumentClient();
+const tableName = process.env.USERS_TABLE_NAME;
+const TWO_WEEKS = 14 * 24 * 60 * 60 * 1000;
+
+module.exports.handler = async event => {
+  try {
+    const { token } = JSON.parse(event.body);
+
+    // get user id from path parameter
+    const userId = event.pathParameters.userId;
+
+    const result = await getUser(userId);
+    // if user does not have Item as property, there was no user found
+    if (!('Item' in result) || typeof result.Item === 'undefined') {
+      return errorResponse(404, 'No user found with the passed user id');
+    }
+
+    const user = result.Item;
+
+    // If tokens match confirm user
+    if (typeof token !== 'undefined' && user.customToken.token === token) {
+      if (new Date() - new Date(user.customToken.timestamp) > TWO_WEEKS) {
+        return errorResponse(400, 'Token is expired');
+      }
+
+      // Get ip address from request (needed for user confirmation)
+      const ipAddress = event.requestContext.identity.sourceIp;
+
+      await confirmUser(userId, token, ipAddress);
+
+      return {
+        statusCode: 204,
+        headers: {
+          'Access-Control-Allow-Origin': '*',
+          'Content-Type': 'application/json',
+        },
+        isBase64Encoded: false,
+      };
+    }
+
+    return errorResponse(400, 'Token missing or token mismatch');
+  } catch (error) {
+    console.log('Error', error);
+    return errorResponse(500, 'Error confirming useer');
+  }
+};
+
+const confirmUser = (userId, token, ipAddress) => {
+  const params = {
+    TableName: tableName,
+    Key: { cognitoId: userId },
+    UpdateExpression: 'SET confirmed = :confirmed',
+    ExpressionAttributeValues: {
+      ':confirmed': {
+        value: true,
+        timestamp: new Date().toISOString(),
+        token,
+        ipAddress,
+      },
+    },
+  };
+
+  return ddb.update(params).promise();
+};

--- a/utils/config.js
+++ b/utils/config.js
@@ -1,3 +1,5 @@
+const SECRET_CONFIG = require('./secretConfig');
+
 module.exports = {
   PROD_USERS_TABLE_NAME: 'prod-users',
   PROD_SIGNATURES_TABLE_NAME: 'prod-signatures',
@@ -9,4 +11,6 @@ module.exports = {
   PROD_MUNICIPALITIES_TABLE_NAME: 'prod-municipalities',
   PROD_USER_MUNICIPALITY_TABLE_NAME: 'prod-users-municipalities',
   DEV_USER_POOL_ID: 'eu-central-1_SYtDaO0qH',
+  API_KEY: SECRET_CONFIG.API_KEY,
+  API_SECRET: SECRET_CONFIG.API_SECRET,
 };

--- a/utils/refactorDatabase/addTokens/index.js
+++ b/utils/refactorDatabase/addTokens/index.js
@@ -1,0 +1,40 @@
+const { getAllUnconfirmedUsers } = require('../../shared/users/getUsers');
+const AWS = require('aws-sdk');
+
+const config = { region: 'eu-central-1' };
+const ddb = new AWS.DynamoDB.DocumentClient(config);
+
+const { PROD_USERS_TABLE_NAME } = require('../../config');
+
+const Bottleneck = require('bottleneck');
+const uuid = require('uuid/v4');
+
+const limiter = new Bottleneck({ minTime: 100, maxConcurrent: 2 });
+
+const addTokens = async () => {
+  const users = await getAllUnconfirmedUsers(PROD_USERS_TABLE_NAME);
+  let count = 0;
+
+  for (const user of users) {
+    await limiter.schedule(async () => {
+      await addToken(user);
+    });
+    console.log('refactored', user.cognitoId, count++, users.length);
+  }
+};
+
+const addToken = async user => {
+  const params = {
+    TableName: PROD_USERS_TABLE_NAME,
+    Key: { cognitoId: user.cognitoId },
+    UpdateExpression: 'SET customToken =  :customToken',
+    ExpressionAttributeValues: {
+      ':customToken': { token: uuid(), timestamp: new Date().toISOString() },
+    },
+    ReturnValues: 'UPDATED_NEW',
+  };
+
+  await ddb.update(params).promise();
+};
+
+addTokens();

--- a/utils/sendMailsForConfirmation/index.js
+++ b/utils/sendMailsForConfirmation/index.js
@@ -1,0 +1,53 @@
+const { API_KEY, API_SECRET, PROD_USERS_TABLE_NAME } = require('../config');
+const { getAllUnconfirmedUsers } = require('../shared/users/getUsers');
+
+const mailjet = require('node-mailjet').connect(API_KEY, API_SECRET);
+
+const run = async () => {
+  console.log('Getting users');
+  const users = await getAllUnconfirmedUsers(PROD_USERS_TABLE_NAME);
+
+  console.log(users.length);
+
+  for (const user of users) {
+    if (new Date(user.createdAt) > new Date('2021-02-20')) {
+      // Get token of user
+      if ('customToken' in user) {
+        const token = user.customToken.token;
+
+        await sendMail(user.email, user.cognitoId, token);
+      } else {
+        console.log('No token for some reason', user.cognitoId);
+      }
+    }
+  }
+};
+
+const sendMail = (email, userId, token) => {
+  const params = {
+    Messages: [
+      {
+        To: [
+          {
+            Email: email,
+          },
+        ],
+        TemplateID: 2809435,
+        TemplateLanguage: true,
+        TemplateErrorReporting: {
+          Email: 'valentin@expedition-grundeinkommen.de',
+          Name: 'Vali',
+        },
+        // TemplateErrorDeliver: true,
+        Variables: {
+          userId,
+          token,
+        },
+      },
+    ],
+  };
+
+  return mailjet.post('send', { version: 'v3.1' }).request(params);
+};
+
+run();


### PR DESCRIPTION
A new endpoint to confirm a user. It receives a token via the request body. If the token is the same as in the user record, the user is confirmed. The pr also includes a script to add tokens to all unconfirmed users and a script to send mails to those people. 

@nmauersberg You don't really need to the anything here, since I already triggered the scripts for the dev backend and you'll test the frontend anyway. Maybe look over the code. :) 